### PR TITLE
Delete i2c cmd_mux semaphore more cleanly

### DIFF
--- a/components/driver/i2c.c
+++ b/components/driver/i2c.c
@@ -367,7 +367,9 @@ esp_err_t i2c_driver_delete(i2c_port_t i2c_num)
     p_i2c->intr_handle = NULL;
 
     if (p_i2c->cmd_mux) {
+        // Let any command in progress finish.
         xSemaphoreTake(p_i2c->cmd_mux, portMAX_DELAY);
+        xSemaphoreGive(p_i2c->cmd_mux);
         vSemaphoreDelete(p_i2c->cmd_mux);
     }
     if (p_i2c_obj[i2c_num]->cmd_evt_queue) {


### PR DESCRIPTION
Adding this `xSemaphoreGive(p_i2c->cmd_mux)` or removing the `xSemaphoreTake(p_i2c->cmd_mux, portMAX_DELAY)` prevents this crash:
```python
import board,busio

i2c = busio.I2C(board.SCL, board.SDA)
i2c.deinit()

import wifi
```

Fixing this also depends on other changes in CircuitPython, reverting the i2c driver managment back to `i2c_driver_install()` and `i2c_driver_delete()`, and not trying to keep the instances around.