### PR TITLE
Only pin gdbgui (and deps) on windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,15 +19,16 @@ pyparsing>=2.0.3,<2.4.0
 pyelftools>=0.22
 idf-component-manager~=1.0
 
-gdbgui==0.13.2.0
+gdbgui
+gdbgui==0.13.2.0; sys_platform == "win32"
 # 0.13.2.1 supports Python 3.6+ only
 # Windows is not supported since 0.14.0.0. See https://github.com/cs01/gdbgui/issues/348
-pygdbmi<=0.9.0.2
+pygdbmi<=0.9.0.2; sys_platform=="win32"
 # The pygdbmi required max version 0.9.0.2 since 0.9.0.3 is not compatible with latest gdbgui (>=0.13.2.0)
 # A compatible Socket.IO should be used. See https://github.com/miguelgrinberg/python-socketio/issues/578
-python-socketio<5
-jinja2<3.1  # See https://github.com/espressif/esp-idf/issues/8760
-itsdangerous<2.1
+python-socketio<5; sys_platform=="win32"
+jinja2<3.1; sys_platform=="win32"  # See https://github.com/espressif/esp-idf/issues/8760
+itsdangerous<2.1; sys_platform=="win32"
 
 kconfiglib==13.7.1
 


### PR DESCRIPTION
This is needed to allow circuitpython's espressif port to build with Python 3.11.