### PR TITLE
Add getter for PSRAM address

### DIFF
--- a/components/esp_psram/esp_psram.c
+++ b/components/esp_psram/esp_psram.c
@@ -390,6 +390,15 @@ size_t esp_psram_get_size(void)
     return (size_t)available_size;
 }
 
+uint8_t* esp_psram_get_address(void)
+{
+    if (!s_psram_ctx.is_initialised) {
+        return NULL;
+    }
+
+    return s_psram_ctx.mapped_regions[PSRAM_MEM_8BIT_ALIGNED].vaddr_start;
+}
+
 uint8_t esp_psram_io_get_cs_io(void)
 {
     return esp_psram_impl_get_cs_io();

--- a/components/esp_psram/include/esp_psram.h
+++ b/components/esp_psram/include/esp_psram.h
@@ -42,6 +42,13 @@ bool esp_psram_is_initialized(void);
  */
 size_t esp_psram_get_size(void);
 
+/**
+ * @brief Get the memory mapped address of the attached PSRAM chip
+ *
+ * @return Pointer to the start of PSRAM memory, or NULL if PSRAM isn't successfully initialized
+ */
+uint8_t* esp_psram_get_address(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
In IDF5, the location is dynamic. The fixed address we used to use is incorrect.