### PR TITLE
Set host list to NULL after freeing items

### DIFF
--- a/components/mdns/mdns.c
+++ b/components/mdns/mdns.c
@@ -2660,6 +2660,7 @@ static void free_delegated_hostnames(void)
         host = host->next;
         free(item);
     }
+    _mdns_host_list = NULL;
 }
 
 static bool _mdns_delegate_hostname_remove(const char * hostname)


### PR DESCRIPTION
Otherwise, we crash next time we use the list because it points to freed memory.