### PR TITLE
ULP component: Fix FSM and RISCV being mutually exclusive at compile time

### DIFF
--- a/components/ulp/CMakeLists.txt
+++ b/components/ulp/CMakeLists.txt
@@ -42,7 +42,9 @@ if(CONFIG_ULP_COPROC_TYPE_FSM OR CONFIG_ULP_COPROC_TYPE_RISCV)
             "ulp_fsm/ulp.c"
             "ulp_fsm/ulp_macro.c")
 
-    elseif(CONFIG_ULP_COPROC_TYPE_RISCV)
+    endif()
+
+    if(CONFIG_ULP_COPROC_TYPE_RISCV)
         list(APPEND srcs
             "ulp_riscv/ulp_riscv.c"
             "ulp_riscv/ulp_riscv_lock.c"

--- a/components/ulp/Kconfig
+++ b/components/ulp/Kconfig
@@ -8,23 +8,15 @@ menu "Ultra Low Power (ULP) Co-processor"
             Enable this feature if you plan to use the ULP Co-processor.
             Once this option is enabled, further ULP co-processor configuration will appear in the menu.
 
-    choice ULP_COPROC_TYPE
-        prompt "ULP Co-processor type"
-        depends on ULP_COPROC_ENABLED
-        default ULP_COPROC_TYPE_RISCV if (IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3)
-        help
-            Choose the ULP Coprocessor type: ULP FSM (Finite State Machine) or ULP RISC-V.
-
-        config ULP_COPROC_TYPE_FSM
-            bool "ULP FSM (Finite State Machine)"
-            depends on SOC_ULP_FSM_SUPPORTED
-        config ULP_COPROC_TYPE_RISCV
-            bool "ULP RISC-V"
-            depends on SOC_RISCV_COPROC_SUPPORTED
-        config ULP_COPROC_TYPE_LP_CORE
-            bool "LP core RISC-V"
-            depends on SOC_LP_CORE_SUPPORTED
-    endchoice
+    config ULP_COPROC_TYPE_FSM
+        bool "Enable ULP FSM (Finite State Machine)"
+        depends on (SOC_ULP_FSM_SUPPORTED && ULP_COPROC_ENABLED)
+    config ULP_COPROC_TYPE_RISCV
+        bool "Enable ULP RISC-V"
+        depends on (SOC_RISCV_COPROC_SUPPORTED && ULP_COPROC_ENABLED)
+    config ULP_COPROC_TYPE_LP_CORE
+        bool "Enable LP core RISC-V"
+        depends on (SOC_LP_CORE_SUPPORTED && ULP_COPROC_ENABLED)
 
     config ULP_COPROC_RESERVE_MEM
         int

--- a/components/ulp/Kconfig
+++ b/components/ulp/Kconfig
@@ -11,9 +11,15 @@ menu "Ultra Low Power (ULP) Co-processor"
     config ULP_COPROC_TYPE_FSM
         bool "Enable ULP FSM (Finite State Machine)"
         depends on (SOC_ULP_FSM_SUPPORTED && ULP_COPROC_ENABLED)
+        help
+            Note: On devices with both ULP FSM and ULP RISC-V, both ULPs can be enabled simultaneously at compile-time, 
+            but may not be used simultaneously at run-time. 
     config ULP_COPROC_TYPE_RISCV
         bool "Enable ULP RISC-V"
         depends on (SOC_RISCV_COPROC_SUPPORTED && ULP_COPROC_ENABLED)
+        help
+            Note: On devices with both ULP FSM and ULP RISC-V, both ULPs can be enabled simultaneously at compile-time, 
+            but may not be used simultaneously at run-time. 
     config ULP_COPROC_TYPE_LP_CORE
         bool "Enable LP core RISC-V"
         depends on (SOC_LP_CORE_SUPPORTED && ULP_COPROC_ENABLED)


### PR DESCRIPTION
This is a fix for https://github.com/espressif/esp-idf/issues/12999, that allows both the FSM and RISCV ULP to be enabled simultaneously at compile time. 

Should this PR get merged, this discussion https://github.com/adafruit/circuitpython/pull/9277/ and this issue https://github.com/adafruit/circuitpython/issues/8770 could be resolved.